### PR TITLE
feat: Add environment name to pricing estimator

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,23 +26,26 @@ def index():
 def calculate_cost():
     data = request.get_json()
 
+    environment_name = data.get('environment_name')
     subscriber_count = data.get('subscriber_count')
     price_tolerance = data.get('price_tolerance')
     region = data.get('region')
-    server_counts = data.get('server_counts') # New variable for dynamic server counts
+    server_counts = data.get('server_counts')
 
-    if not all([subscriber_count, price_tolerance, region, server_counts]):
+    if not all([environment_name, subscriber_count, price_tolerance, region, server_counts]):
         return jsonify({"error": "Missing required parameters"}), 400
 
     # Call your main pricing function with the data from the front-end
     recommendations, total_cost = get_total_estimated_monthly_cost(
+        environment_name=environment_name,
         subscriber_count=int(subscriber_count),
         price_tolerance=price_tolerance,
         region=region,
-        server_counts=server_counts # Pass the new variable
+        server_counts=server_counts
     )
 
     response = {
+        "environment_name": environment_name,
         "recommendations": recommendations,
         "total_cost": total_cost
     }

--- a/index.html
+++ b/index.html
@@ -31,6 +31,11 @@
 
         <!-- Input Form -->
         <div class="space-y-6">
+            <!-- Environment Name Input -->
+            <div>
+                <label for="environment-name" class="block text-sm font-medium text-gray-700">Environment Name</label>
+                <input type="text" id="environment-name" placeholder="e.g., Production, Staging" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2">
+            </div>
             <!-- Subscriber Count Input with Slider -->
             <div>
                 <label for="subscriber-count-display" class="block text-sm font-medium text-gray-700">Subscriber Count</label>
@@ -102,6 +107,7 @@
         const resultsContent = document.getElementById('results-content');
         const priceToleranceInput = document.getElementById('price-tolerance');
         const regionInput = document.getElementById('region');
+        const environmentNameInput = document.getElementById('environment-name'); // New input field
 
         // New server count input fields
         const sqlServerCountInput = document.getElementById('sql-server-count');
@@ -113,7 +119,7 @@
         });
 
         // This is the new function that calls your Flask backend
-        const fetchRealApiData = async (subscriberCount, priceTolerance, region, serverCounts) => {
+        const fetchRealApiData = async (environmentName, subscriberCount, priceTolerance, region, serverCounts) => {
             try {
                 const response = await fetch('http://127.0.0.1:5000/calculate', {
                     method: 'POST',
@@ -121,10 +127,11 @@
                         'Content-Type': 'application/json',
                     },
                     body: JSON.stringify({
+                        environment_name: environmentName, // Pass the new variable
                         subscriber_count: subscriberCount,
                         price_tolerance: priceTolerance,
                         region: region,
-                        server_counts: serverCounts // Pass the dynamic server counts
+                        server_counts: serverCounts
                     })
                 });
 
@@ -142,6 +149,7 @@
         // Handle button click event
         calculateBtn.addEventListener('click', async () => {
             // Get values from inputs
+            const environmentName = environmentNameInput.value || 'Untitled Environment'; // Default if empty
             const subscriberCount = parseInt(slider.value);
             const priceTolerance = priceToleranceInput.value;
             const region = regionInput.value;
@@ -162,7 +170,7 @@
             `;
 
             // Call the real API
-            const result = await fetchRealApiData(subscriberCount, priceTolerance, region, serverCounts);
+            const result = await fetchRealApiData(environmentName, subscriberCount, priceTolerance, region, serverCounts);
 
             // Check for an error response
             if (result.error) {
@@ -175,6 +183,7 @@
                 <div class="bg-gray-50 p-4 rounded-md">
                     <h3 class="text-lg font-semibold text-gray-700 mb-2">Configuration Details</h3>
                     <ul class="list-disc list-inside space-y-1 text-gray-600">
+                        <li>Environment: <strong>${result.environment_name}</strong></li>
                         <li>Subscriber Count: <strong>${subscriberCount.toLocaleString()}</strong></li>
                         <li>Price Tolerance: <strong>${priceTolerance.charAt(0).toUpperCase() + priceTolerance.slice(1)}</strong></li>
                         <li>Azure Region: <strong>${region.toUpperCase()}</strong></li>

--- a/pricing_script.py
+++ b/pricing_script.py
@@ -189,7 +189,7 @@ def fetch_all_storage_prices(region="eastus"):
     return all_prices
 
 # This function has been updated to accept the `server_counts` dictionary
-def get_total_estimated_monthly_cost(subscriber_count, price_tolerance, region="eastus", hours_in_month=730, server_counts={}):
+def get_total_estimated_monthly_cost(environment_name, subscriber_count, price_tolerance, region="eastus", hours_in_month=730, server_counts={}):
     """
     Calculates the total estimated monthly cost for an environment using a pre-fetched price list and dynamic server counts.
     """
@@ -204,7 +204,7 @@ def get_total_estimated_monthly_cost(subscriber_count, price_tolerance, region="
     recommendations = get_azure_recommendations(subscriber_count, price_tolerance)
     total_cost = 0.0
     
-    print(f"\n--- Pricing Estimate for {subscriber_count} Subscribers ({price_tolerance.upper()}) ---")
+    print(f"\n--- Pricing Estimate for {environment_name}: {subscriber_count} Subscribers ({price_tolerance.upper()}) ---")
 
     itemized_costs = {}
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Flask-Cors
+requests


### PR DESCRIPTION
This feature adds the ability for you to specify a name for your environment when calculating pricing estimates.

The changes include:
- A new "Environment Name" text input field in `index.html`.
- Updated javascript in `index.html` to send the environment name to the backend.
- A modified `/calculate` endpoint in `app.py` to accept and process the environment name.
- An updated pricing script in `pricing_script.py` to include the environment name in the output.
- The environment name is displayed in the results section on the frontend.